### PR TITLE
domain transfer: extend DataRequest with custom properties field

### DIFF
--- a/data-protocols/ids/ids-api-transfer/build.gradle.kts
+++ b/data-protocols/ids/ids-api-transfer/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
 
-    testImplementation("org.glassfish.jersey.media:jersey-media-multipart:${jerseyVersion}")
+    testImplementation("org.glassfish.jersey.core:jersey-common:${jerseyVersion}")
     testImplementation("com.github.javafaker:javafaker:1.0.2")
 
 }

--- a/data-protocols/ids/ids-api-transfer/build.gradle.kts
+++ b/data-protocols/ids/ids-api-transfer/build.gradle.kts
@@ -14,6 +14,7 @@
 
 val infoModelVersion: String by project
 val rsApi: String by project
+val jerseyVersion: String by project
 
 plugins {
     `java-library`
@@ -27,6 +28,9 @@ dependencies {
     api("de.fraunhofer.iais.eis.ids.infomodel:java:${infoModelVersion}")
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
+
+    testImplementation("org.glassfish.jersey.media:jersey-media-multipart:${jerseyVersion}")
+    testImplementation("com.github.javafaker:javafaker:1.0.2")
 
 }
 

--- a/data-protocols/ids/ids-api-transfer/src/main/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestController.java
+++ b/data-protocols/ids/ids-api-transfer/src/main/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestController.java
@@ -113,7 +113,8 @@ public class ArtifactRequestController {
 
 
         // TODO this needs to be deserialized from the artifact request message
-        var destinationMap = (Map<String, Object>) message.getProperties().get(ArtifactRequestController.DESTINATION_KEY);
+        Map<String, Object> messageProperties = message.getProperties();
+        var destinationMap = (Map<String, Object>) messageProperties.get(ArtifactRequestController.DESTINATION_KEY);
         var type = (String) destinationMap.get("type");
 
         Map<String, String> properties = (Map<String, String>) destinationMap.get("properties");
@@ -126,10 +127,10 @@ public class ArtifactRequestController {
                 .assetId(asset.getId())
                 .dataDestination(dataDestination)
                 .protocol(IDS_REST)
-                .properties((Map<String, String>) message.getProperties().get(ArtifactRequestController.PROPERTIES_KEY))
+                .additionalProperties((Map<String, String>) messageProperties.get(ArtifactRequestController.PROPERTIES_KEY))
                 .build();
 
-        var destinationToken = (String) message.getProperties().get(ArtifactRequestController.TOKEN_KEY);
+        var destinationToken = (String) messageProperties.get(ArtifactRequestController.TOKEN_KEY);
 
         if (destinationToken != null) {
             vault.storeSecret(secretName, destinationToken);

--- a/data-protocols/ids/ids-api-transfer/src/main/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestController.java
+++ b/data-protocols/ids/ids-api-transfer/src/main/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestController.java
@@ -52,6 +52,7 @@ import static org.eclipse.dataspaceconnector.ids.spi.Protocols.IDS_REST;
 public class ArtifactRequestController {
     private static final String TOKEN_KEY = "dataspaceconnector-destination-token";
     private static final String DESTINATION_KEY = "dataspaceconnector-data-destination";
+    private static final String PROPERTIES_KEY = "dataspaceconnector-properties";
 
     private final DapsService dapsService;
     private final AssetIndex assetIndex;
@@ -120,7 +121,13 @@ public class ArtifactRequestController {
 
         var dataDestination = DataAddress.Builder.newInstance().type(type).properties(properties).keyName(secretName).build();
 
-        var dataRequest = DataRequest.Builder.newInstance().id(randomUUID().toString()).assetId(asset.getId()).dataDestination(dataDestination).protocol(IDS_REST).build();
+        var dataRequest = DataRequest.Builder.newInstance()
+                .id(randomUUID().toString())
+                .assetId(asset.getId())
+                .dataDestination(dataDestination)
+                .protocol(IDS_REST)
+                .properties((Map<String, String>) message.getProperties().get(ArtifactRequestController.PROPERTIES_KEY))
+                .build();
 
         var destinationToken = (String) message.getProperties().get(ArtifactRequestController.TOKEN_KEY);
 

--- a/data-protocols/ids/ids-api-transfer/src/test/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestControllerTest.java
+++ b/data-protocols/ids/ids-api-transfer/src/test/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestControllerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 Microsoft Corporation
+ *  Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
  *
  *  This program and the accompanying materials are made available under the
  *  terms of the Apache License, Version 2.0 which is available at

--- a/data-protocols/ids/ids-api-transfer/src/test/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestControllerTest.java
+++ b/data-protocols/ids/ids-api-transfer/src/test/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestControllerTest.java
@@ -61,7 +61,7 @@ public class ArtifactRequestControllerTest {
     private TransferProcessManager manager;
 
     private final String consumerConnectorAddress = faker.internet().url();
-    private final String artifactMessageId = faker.lorem().characters();
+    private final String artifactMessageId = faker.internet().uuid();
     private final String assetId = faker.internet().url();
 
 

--- a/data-protocols/ids/ids-api-transfer/src/test/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestControllerTest.java
+++ b/data-protocols/ids/ids-api-transfer/src/test/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestControllerTest.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright (c) 2021 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Catena-X Consortium - initial API and implementation
+ *
+ */
+package org.eclipse.dataspaceconnector.ids.api.transfer;
+
+import com.github.javafaker.Faker;
+import de.fraunhofer.iais.eis.ArtifactRequestMessage;
+import de.fraunhofer.iais.eis.ArtifactRequestMessageBuilder;
+import de.fraunhofer.iais.eis.DynamicAttributeTokenBuilder;
+import org.easymock.EasyMock;
+import org.easymock.IArgumentMatcher;
+import org.eclipse.dataspaceconnector.ids.spi.daps.DapsService;
+import org.eclipse.dataspaceconnector.ids.spi.policy.IdsPolicyService;
+import org.eclipse.dataspaceconnector.policy.engine.PolicyEvaluationResult;
+import org.eclipse.dataspaceconnector.policy.model.Policy;
+import org.eclipse.dataspaceconnector.spi.asset.AssetIndex;
+import org.eclipse.dataspaceconnector.spi.iam.VerificationResult;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.policy.PolicyRegistry;
+import org.eclipse.dataspaceconnector.spi.security.Vault;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferInitiateResponse;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessManager;
+import org.eclipse.dataspaceconnector.spi.types.domain.asset.Asset;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.easymock.EasyMock.*;
+import static org.easymock.EasyMock.verify;
+import static org.eclipse.dataspaceconnector.ids.spi.Protocols.IDS_REST;
+
+public class ArtifactRequestControllerTest {
+
+    public static final String DESTINATION_KEY = "dataspaceconnector-data-destination";
+    public static final String PROPERTIES_KEY = "dataspaceconnector-properties";
+    static Faker faker = new Faker();
+
+    private ArtifactRequestController controller;
+    private TransferProcessManager manager;
+
+    private final String consumerConnectorAddress = faker.internet().url();
+    private final String artifactMessageId = faker.lorem().characters();
+    private final String assetId = faker.internet().url();
+
+
+    @BeforeEach
+    public void setUp() {
+        manager = mock(TransferProcessManager.class);
+
+        DapsService dapsService = niceMock(DapsService.class);
+        VerificationResult verificationResult = niceMock(VerificationResult.class);
+        AssetIndex assetIndex = niceMock(AssetIndex.class);
+        Asset asset = niceMock(Asset.class);
+        PolicyRegistry policyRegistry = niceMock(PolicyRegistry.class);
+        IdsPolicyService policyService = niceMock(IdsPolicyService.class);
+        PolicyEvaluationResult policyEvaluationResult = niceMock(PolicyEvaluationResult.class);
+
+        expect(dapsService.verifyAndConvertToken(anyString())).andReturn(verificationResult);
+        expect(verificationResult.valid()).andReturn(true);
+        expect(assetIndex.findById(assetId)).andReturn(asset);
+        expect(asset.getId()).andReturn(assetId);
+        expect(policyRegistry.resolvePolicy(anyObject())).andReturn(niceMock(Policy.class));
+        expect(policyEvaluationResult.valid()).andReturn(true);
+        expect(policyService.evaluateRequest(same(consumerConnectorAddress), same(artifactMessageId), anyObject(), anyObject())).andReturn(policyEvaluationResult);
+
+        replay(dapsService, verificationResult, assetIndex, asset, policyRegistry, policyService, policyEvaluationResult);
+
+        controller = new ArtifactRequestController(dapsService, assetIndex, manager, policyService, policyRegistry, mock(Vault.class), mock(Monitor.class));
+    }
+
+
+    @Test
+    public void initiateDataRequest() {
+
+        // prepare
+        var additionalProperties = Map.of(faker.lorem().word(), faker.lorem().word(), faker.lorem().word(), faker.lorem().word());
+        var type = faker.lorem().word();
+        var secretName = faker.lorem().word();
+        ArtifactRequestMessage artifactRequestMessage = createArtifactRequestMessage(additionalProperties, type, secretName);
+
+        var expectedDataRequest = DataRequest.Builder.newInstance()
+                .assetId(assetId)
+                .dataDestination(DataAddress.Builder.newInstance().type(type).keyName(secretName).build())
+                .protocol(IDS_REST)
+                .additionalProperties(additionalProperties)
+                .build();
+
+        expect(manager.initiateProviderRequest(dataRequestMatcher(expectedDataRequest))).andReturn(TransferInitiateResponse.Builder.newInstance().build()).times(1);
+
+        // record
+        replay(manager);
+
+        // invoke
+        controller.request(artifactRequestMessage);
+
+        // verify
+        verify(manager);
+    }
+
+    @NotNull
+    private ArtifactRequestMessage createArtifactRequestMessage(Map<String, String> additionalProperties, String type, String secretName) {
+        ArtifactRequestMessage artifactRequestMessage = new ArtifactRequestMessageBuilder(URI.create(artifactMessageId))
+                ._securityToken_(new DynamicAttributeTokenBuilder()
+                        ._tokenValue_(faker.lorem().word())
+                        .build())
+                ._requestedArtifact_(URI.create(assetId))
+                ._issuerConnector_(URI.create(consumerConnectorAddress))
+                .build();
+
+        var destinationMap = Map.of("type", type, "keyName", secretName, "properties", new HashMap<>());
+        artifactRequestMessage.setProperty(DESTINATION_KEY, destinationMap);
+
+        artifactRequestMessage.setProperty(PROPERTIES_KEY, additionalProperties);
+        return artifactRequestMessage;
+    }
+
+    public static DataRequest dataRequestMatcher(DataRequest dataRequest) {
+        EasyMock.reportMatcher(new IArgumentMatcher() {
+            @Override
+            public boolean matches(Object argument) {
+                return argument instanceof DataRequest
+                        && dataRequest.getDataDestination().getKeyName().equals(((DataRequest) argument).getDataDestination().getKeyName())
+                        && dataRequest.getDataDestination().getType().equals(((DataRequest) argument).getDataDestination().getType())
+                        && dataRequest.getDataDestination().getProperties().equals(((DataRequest) argument).getDataDestination().getProperties())
+                        && dataRequest.getAssetId().equals(((DataRequest) argument).getAssetId())
+                        && dataRequest.getAdditionalProperties().equals(((DataRequest) argument).getAdditionalProperties())
+                        && dataRequest.getProtocol().equals(((DataRequest) argument).getProtocol());
+            }
+
+            @Override
+            public void appendTo(StringBuffer buffer) {
+                buffer.append("DataRequests don't match.");
+            }
+        });
+        return null;
+    }
+}

--- a/data-protocols/ids/ids-api-transfer/src/test/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestControllerTest.java
+++ b/data-protocols/ids/ids-api-transfer/src/test/java/org/eclipse/dataspaceconnector/ids/api/transfer/ArtifactRequestControllerTest.java
@@ -41,7 +41,13 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.easymock.EasyMock.*;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.niceMock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.same;
 import static org.easymock.EasyMock.verify;
 import static org.eclipse.dataspaceconnector.ids.spi.Protocols.IDS_REST;
 
@@ -134,13 +140,13 @@ public class ArtifactRequestControllerTest {
         EasyMock.reportMatcher(new IArgumentMatcher() {
             @Override
             public boolean matches(Object argument) {
-                return argument instanceof DataRequest
-                        && dataRequest.getDataDestination().getKeyName().equals(((DataRequest) argument).getDataDestination().getKeyName())
-                        && dataRequest.getDataDestination().getType().equals(((DataRequest) argument).getDataDestination().getType())
-                        && dataRequest.getDataDestination().getProperties().equals(((DataRequest) argument).getDataDestination().getProperties())
-                        && dataRequest.getAssetId().equals(((DataRequest) argument).getAssetId())
-                        && dataRequest.getAdditionalProperties().equals(((DataRequest) argument).getAdditionalProperties())
-                        && dataRequest.getProtocol().equals(((DataRequest) argument).getProtocol());
+                return argument instanceof DataRequest &&
+                        dataRequest.getDataDestination().getKeyName().equals(((DataRequest) argument).getDataDestination().getKeyName()) &&
+                        dataRequest.getDataDestination().getType().equals(((DataRequest) argument).getDataDestination().getType()) &&
+                        dataRequest.getDataDestination().getProperties().equals(((DataRequest) argument).getDataDestination().getProperties()) &&
+                        dataRequest.getAssetId().equals(((DataRequest) argument).getAssetId()) &&
+                        dataRequest.getAdditionalProperties().equals(((DataRequest) argument).getAdditionalProperties()) &&
+                        dataRequest.getProtocol().equals(((DataRequest) argument).getProtocol());
             }
 
             @Override

--- a/data-protocols/ids/ids-core/build.gradle.kts
+++ b/data-protocols/ids/ids-core/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 
     implementation("jakarta.ws.rs:jakarta.ws.rs-api:${rsApi}")
     implementation(project(":core:policy:policy-engine"))
+    testImplementation("com.github.javafaker:javafaker:1.0.2")
 }
 
 

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSender.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSender.java
@@ -22,6 +22,7 @@ import de.fraunhofer.iais.eis.TokenFormat;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
 import org.eclipse.dataspaceconnector.spi.message.MessageContext;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSender.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSender.java
@@ -93,6 +93,8 @@ public class DataRequestMessageSender implements IdsMessageSender<DataRequest, V
                 .build();
         artifactMessage.setProperty("dataspaceconnector-data-destination", dataRequest.getDataDestination());
 
+        artifactMessage.setProperty("dataspaceconnector-properties", dataRequest.getProperties());
+
         var processId = context.getProcessId();
 
         var serializedToken = vault.resolveSecret(dataRequest.getDataDestination().getKeyName());

--- a/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSender.java
+++ b/data-protocols/ids/ids-core/src/main/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSender.java
@@ -30,7 +30,6 @@ import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
 import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcess;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
 import java.util.Objects;
@@ -93,7 +92,7 @@ public class DataRequestMessageSender implements IdsMessageSender<DataRequest, V
                 .build();
         artifactMessage.setProperty("dataspaceconnector-data-destination", dataRequest.getDataDestination());
 
-        artifactMessage.setProperty("dataspaceconnector-properties", dataRequest.getProperties());
+        artifactMessage.setProperty("dataspaceconnector-properties", dataRequest.getAdditionalProperties());
 
         var processId = context.getProcessId();
 

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSenderTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSenderTest.java
@@ -1,3 +1,16 @@
+/*
+ *  Copyright (c) 2021 Copyright Holder (Catena-X Consortium)
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Catena-X Consortium - initial API and implementation
+ *
+ */
 package org.eclipse.dataspaceconnector.ids.core.message;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSenderTest.java
+++ b/data-protocols/ids/ids-core/src/test/java/org/eclipse/dataspaceconnector/ids/core/message/DataRequestMessageSenderTest.java
@@ -1,0 +1,103 @@
+package org.eclipse.dataspaceconnector.ids.core.message;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.javafaker.Faker;
+import de.fraunhofer.iais.eis.ArtifactRequestMessageImpl;
+import okhttp3.*;
+import okio.Buffer;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.eclipse.dataspaceconnector.spi.iam.IdentityService;
+import org.eclipse.dataspaceconnector.spi.iam.TokenResult;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.security.Vault;
+import org.eclipse.dataspaceconnector.spi.transfer.store.TransferProcessStore;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataAddress;
+import org.eclipse.dataspaceconnector.spi.types.domain.transfer.DataRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.easymock.EasyMock.*;
+import static org.eclipse.dataspaceconnector.ids.spi.Protocols.IDS_REST;
+
+class DataRequestMessageSenderTest {
+
+    public static final String DESTINATION_KEY = "dataspaceconnector-data-destination";
+    public static final String PROPERTIES_KEY = "dataspaceconnector-properties";
+    static Faker faker = new Faker();
+    private final String connectorAddress = "http://" + faker.internet().url();
+    private final String connectorId = faker.internet().url();
+    private final String processId = faker.internet().uuid();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+
+    private DataRequestMessageSender sender;
+    private OkHttpClient httpClient;
+
+    @BeforeEach
+    public void setUp() {
+        httpClient = niceMock(OkHttpClient.class);
+
+        IdentityService identityService = niceMock(IdentityService.class);
+        TokenResult tokenResult = niceMock(TokenResult.class);
+        expect(tokenResult.getToken()).andReturn(faker.lorem().characters());
+        expect(identityService.obtainClientCredentials(connectorId)).andReturn(tokenResult);
+        replay(identityService, tokenResult);
+        sender = new DataRequestMessageSender(connectorId, identityService, niceMock(TransferProcessStore.class), EasyMock.mock(Vault.class), httpClient, mapper, niceMock(Monitor.class));
+    }
+
+    @Test
+    public void initiateIDSMessage() throws IOException {
+        DataRequest dataRequest = createDataRequest();
+        DataAddress dataDestination = dataRequest.getDataDestination();
+
+        // record
+        Capture<Request> requestCapture = newCapture();
+        expect(httpClient.newCall(capture(requestCapture))).andReturn(niceMock(Call.class)).times(1);
+        replay(httpClient);
+
+        // invoke
+        sender.send(dataRequest, () -> processId);
+
+        //verify
+        verify(httpClient);
+
+        var artifactMessageRequest = getArtifactMessageRequest(requestCapture.getValue());
+        assertThat(artifactMessageRequest.getIssuerConnector()).isEqualTo(URI.create(connectorId));
+        assertThat(artifactMessageRequest.getRequestedArtifact()).isEqualTo(URI.create(dataRequest.getAssetId()));
+
+        var properties = artifactMessageRequest.getProperties();
+        assertThat((Map<String, Object>) properties.get(DESTINATION_KEY)).contains(entry("keyName", dataDestination.getKeyName()), entry("type", dataDestination.getType()));
+        assertThat(properties.get(PROPERTIES_KEY)).isEqualTo(dataRequest.getAdditionalProperties());
+
+    }
+
+    private DataRequest createDataRequest() {
+        var additionalProperties = Map.of(faker.internet().uuid(), faker.lorem().word(), faker.internet().uuid(), faker.lorem().word());
+        var keyName = faker.lorem().word();
+        var type = faker.lorem().word();
+        return DataRequest.Builder.newInstance()
+                .connectorId(connectorId)
+                .assetId(faker.internet().url())
+                .dataDestination(DataAddress.Builder.newInstance().keyName(keyName).type(type).build())
+                .protocol(IDS_REST)
+                .additionalProperties(additionalProperties)
+                .connectorAddress(connectorAddress)
+                .build();
+    }
+
+    private ArtifactRequestMessageImpl getArtifactMessageRequest(Request request) throws IOException {
+        Buffer buffer = new Buffer();
+        request.body().writeTo(buffer);
+        String json = buffer.readString(StandardCharsets.UTF_8);
+        return mapper.readValue(json, ArtifactRequestMessageImpl.class);
+    }
+
+}

--- a/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/policy/IdsPolicyService.java
+++ b/data-protocols/ids/ids-spi/src/main/java/org/eclipse/dataspaceconnector/ids/spi/policy/IdsPolicyService.java
@@ -27,7 +27,7 @@ import org.eclipse.dataspaceconnector.spi.iam.ClaimToken;
 public interface IdsPolicyService {
 
     /**
-     * Evaluates a request made by a client for an artifact.
+     * Evaluates a request made by a consumer for an artifact.
      *
      * @param consumerConnectorId the id of the connector making the request
      * @param correlationId       an identifier that can be used to retrieve additional information about the request such as a pre-payment or pre-authorization receipt

--- a/docs/diagrams/distributed-identity/data.request.puml
+++ b/docs/diagrams/distributed-identity/data.request.puml
@@ -1,6 +1,6 @@
 @startuml
 
-participant "Client Connector" as cc
+participant "Consumer Connector" as cc
 participant "Client Hub" as ch
 participant "Provider Connector" as pc
 participant "Revocation List" as rl

--- a/docs/diagrams/distributed-identity/service.discovery.puml
+++ b/docs/diagrams/distributed-identity/service.discovery.puml
@@ -1,5 +1,5 @@
 @startuml
-participant "Client Connector" as cc
+participant "Consumer Connector" as cc
 participant "Provider Connector Identity Hub" as pcih
 participant "Registration Service" as rs
 participant "ION Network" as ion

--- a/extensions/in-memory/contractdefinition-store-memory/build.gradle.kts
+++ b/extensions/in-memory/contractdefinition-store-memory/build.gradle.kts
@@ -22,8 +22,8 @@ dependencies {
 
 publishing {
     publications {
-        create<MavenPublication>("in-memory.contractdefinition-store") {
-            artifactId = "in-memory.contractdefinition-store"
+        create<MavenPublication>("contractdefinition-store-memory") {
+            artifactId = "contractdefinition-store-memory"
             from(components["java"])
         }
     }

--- a/extensions/in-memory/negotiation-store-memory/build.gradle.kts
+++ b/extensions/in-memory/negotiation-store-memory/build.gradle.kts
@@ -24,8 +24,8 @@ dependencies {
 }
 publishing {
     publications {
-        create<MavenPublication>("in-memory.negotiation-store") {
-            artifactId = "in-memory.negotiation-store"
+        create<MavenPublication>("contractnegotiation-store-memory") {
+            artifactId = "contractnegotiation-store-memory"
             from(components["java"])
         }
     }

--- a/samples/other/commandline/consumer/src/main/java/org/eclipse/dataspaceconnector/consumer/command/ids/IdsConstants.java
+++ b/samples/other/commandline/consumer/src/main/java/org/eclipse/dataspaceconnector/consumer/command/ids/IdsConstants.java
@@ -18,9 +18,7 @@ import java.net.URI;
 
 public interface IdsConstants {
 
-    String ID = "DAG-X_CLIENT";
-
-    URI ID_URI = URI.create("DAG-X_CLIENT");
+    URI ID_URI = URI.create("EDC_CLIENT");
 
     String VERSION = "1.0";
 }

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import org.eclipse.dataspaceconnector.spi.types.domain.Polymorphic;
 import org.eclipse.dataspaceconnector.spi.types.domain.message.RemoteMessage;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Polymorphic data request.
  */
@@ -44,6 +47,8 @@ public class DataRequest implements RemoteMessage, Polymorphic {
     private DataAddress dataDestination;
 
     private boolean managedResources = true;
+
+    private Map<String, String> properties = new HashMap();
 
     private TransferType transferType;
 
@@ -120,6 +125,13 @@ public class DataRequest implements RemoteMessage, Polymorphic {
         return dataDestination;
     }
 
+    /**
+     * Custom properties that are passed to the provider connector.
+     */
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
     public boolean isManagedResources() {
         return managedResources;
     }
@@ -136,6 +148,7 @@ public class DataRequest implements RemoteMessage, Polymorphic {
                 .dataAddress(dataDestination)
                 .transferType(transferType)
                 .managedResources(managedResources)
+                .properties(properties)
                 .build();
     }
 
@@ -212,6 +225,11 @@ public class DataRequest implements RemoteMessage, Polymorphic {
 
         public Builder managedResources(boolean value) {
             request.managedResources = value;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> value) {
+            request.properties = value;
             return this;
         }
 

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -129,7 +129,7 @@ public class DataRequest implements RemoteMessage, Polymorphic {
      * Custom properties that are passed to the provider connector.
      */
     public Map<String, String> getAdditionalProperties() {
-        return Map.copyOf(additionalProperties);
+        return additionalProperties;
     }
 
     public boolean isManagedResources() {

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -48,7 +48,7 @@ public class DataRequest implements RemoteMessage, Polymorphic {
 
     private boolean managedResources = true;
 
-    private Map<String, String> additionalProperties = new HashMap<>();
+    private Map<String, String> additionalProperties = Map.of();
 
     private TransferType transferType;
 

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/DataRequest.java
@@ -48,7 +48,7 @@ public class DataRequest implements RemoteMessage, Polymorphic {
 
     private boolean managedResources = true;
 
-    private Map<String, String> properties = new HashMap();
+    private Map<String, String> additionalProperties = new HashMap<>();
 
     private TransferType transferType;
 
@@ -128,8 +128,8 @@ public class DataRequest implements RemoteMessage, Polymorphic {
     /**
      * Custom properties that are passed to the provider connector.
      */
-    public Map<String, String> getProperties() {
-        return properties;
+    public Map<String, String> getAdditionalProperties() {
+        return Map.copyOf(additionalProperties);
     }
 
     public boolean isManagedResources() {
@@ -148,7 +148,7 @@ public class DataRequest implements RemoteMessage, Polymorphic {
                 .dataAddress(dataDestination)
                 .transferType(transferType)
                 .managedResources(managedResources)
-                .properties(properties)
+                .additionalProperties(additionalProperties)
                 .build();
     }
 
@@ -228,8 +228,8 @@ public class DataRequest implements RemoteMessage, Polymorphic {
             return this;
         }
 
-        public Builder properties(Map<String, String> value) {
-            request.properties = value;
+        public Builder additionalProperties(Map<String, String> value) {
+            request.additionalProperties = value == null ? null : Map.copyOf(value);
             return this;
         }
 


### PR DESCRIPTION
This PR contains a proposal to solve issue #299 by extending the DataRequest object with a Map of custom properties.

- add properties Map field to DataRequest
- add the properties to the artifactMessage in DataRequestMessageSender so that they are passed to the provider
- read the properties in ArtifactRequestController
- add unit tests for verifying that the properties were passed from DataRequest to ArtifactRequestMessage in consumer and - from ArtifactRequestMessage to DataRequest in provider