### PR TITLE
Add method to cancel transfer processes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,6 +19,6 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
-        run: gradle publish
+        run: gradle publish -PprojectVersion=0.0.1-SNAPSHOT.Agera.${{ github.run_id }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,25 @@
+name: Publish package to the Packages Repository
+
+on:
+  #release:
+  #  types: [created]
+  push:
+    branches:
+      - algattik/publish
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Publish package
+        run: gradle publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.PKG_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.PKG_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,11 +1,7 @@
 name: Publish package to the Packages Repository
 
 on:
-  #release:
-  #  types: [created]
-  push:
-    branches:
-      - algattik/publish
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,5 +21,4 @@ jobs:
       - name: Publish package
         run: gradle publish
         env:
-          MAVEN_USERNAME: ${{ secrets.PKG_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.PKG_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ allprojects {
             repositories {
                 maven {
                     name = "GitHubPackages"
-                    url = uri("https://maven.pkg.github.com/eclipse-datasspaceconnector/dataspaceconnector")
+                    url = uri("https://maven.pkg.github.com/agera-catenax/eclipsedataspaceconnector")
                     credentials {
                         username = System.getenv("GITHUB_ACTOR")
                         password = System.getenv("GITHUB_TOKEN")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ repositories {
 val jetBrainsAnnotationsVersion: String by project
 val jacksonVersion: String by project
 val javaVersion: String by project
+val projectVersion: String by project
 
 val securityType by extra { System.getProperty("security.type", "default") }
 val iamType by extra { System.getProperty("iam.type", "disabled") }
@@ -65,7 +66,7 @@ allprojects {
 
     pluginManager.withPlugin("java-library") {
         group = "org.eclipse.dataspaceconnector"
-        version = "0.0.1-SNAPSHOT.1"
+        version = projectVersion
         dependencies {
             api("org.jetbrains:annotations:${jetBrainsAnnotationsVersion}")
             api("com.fasterxml.jackson.core:jackson-core:${jacksonVersion}")

--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImpl.java
@@ -92,6 +92,13 @@ public class TransferProcessManagerImpl extends TransferProcessObservable implem
         return initiateRequest(PROVIDER, dataRequest);
     }
 
+    @Override
+    public void cancelTransferProcess(String processId) {
+        TransferProcess process = transferProcessStore.find(processId);
+        process.transitionError("Cancelled");
+        transferProcessStore.update(process);
+        invokeForEach(l -> l.error(process));
+    }
 
     private TransferInitiateResponse initiateRequest(TransferProcess.Type type, DataRequest dataRequest) {
         // make the request idempotent: if the process exists, return

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplConsumerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplConsumerTest.java
@@ -223,6 +223,39 @@ class TransferProcessManagerImplConsumerTest {
     }
 
     @Test
+    @DisplayName("checkProvisioned: empty provisioned resources")
+    void verifyCheckProvisioned_emptyProvisionedResoures() throws InterruptedException {
+        //arrange
+        TransferProcess process = createTransferProcess(TransferProcessStates.REQUESTED_ACK);
+
+        var cdl = new CountDownLatch(1);
+
+        //prepare process store
+        TransferProcessStore processStoreMock = mock(TransferProcessStore.class);
+        expect(processStoreMock.nextForState(eq(TransferProcessStates.INITIAL.code()), anyInt())).andReturn(Collections.emptyList());
+        expect(processStoreMock.nextForState(eq(TransferProcessStates.PROVISIONED.code()), anyInt())).andReturn(Collections.emptyList());
+        expect(processStoreMock.nextForState(eq(TransferProcessStates.REQUESTED_ACK.code()), anyInt())).andReturn(Collections.singletonList(process));
+        // flip the latch on the next cycle
+        expect(processStoreMock.nextForState(anyInt(), anyInt())).andAnswer(() -> {
+            cdl.countDown();
+            return Collections.emptyList();
+        }).anyTimes();
+
+        processStoreMock.update(process);
+        expectLastCall().andStubThrow(new AssertionError("update() should not be called as process was not updated"));
+
+        replay(processStoreMock);
+
+        //act
+        transferProcessManager.start(processStoreMock);
+
+        //assert
+        assertThat(cdl.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
+        verify(processStoreMock);
+        assertThat(process.getState()).describedAs("State should be REQUESTED_ACK").isEqualTo(TransferProcessStates.REQUESTED_ACK.code());
+    }
+
+    @Test
     @DisplayName("checkComplete: should transition process with managed resources if checker returns completed")
     void verifyCompletedManagedResources() throws InterruptedException {
         //arrange
@@ -321,8 +354,7 @@ class TransferProcessManagerImplConsumerTest {
             cdl.countDown();
             return Collections.emptyList();
         }).anyTimes();
-        processStoreMock.update(eq(process));
-        expectLastCall().anyTimes();
+        expectLastCall().andStubThrow(new AssertionError("update() should not be called as process was not updated"));
         replay(processStoreMock);
 
         // prepare statuschecker registry
@@ -355,13 +387,14 @@ class TransferProcessManagerImplConsumerTest {
         expect(processStoreMock.nextForState(eq(TransferProcessStates.PROVISIONED.code()), anyInt())).andReturn(Collections.emptyList());
         expect(processStoreMock.nextForState(eq(TransferProcessStates.REQUESTED_ACK.code()), anyInt())).andReturn(Collections.emptyList());
         expect(processStoreMock.nextForState(eq(TransferProcessStates.IN_PROGRESS.code()), anyInt())).andReturn(Collections.singletonList(process));
-        expect(processStoreMock.nextForState(anyInt(), anyInt())).andReturn(Collections.emptyList()).anyTimes();
+        // flip the latch on the next cycle
+        expect(processStoreMock.nextForState(anyInt(), anyInt())).andAnswer(() -> {
+            cdl.countDown();
+            return Collections.emptyList();
+        }).anyTimes();
 
         processStoreMock.update(process);
-        expectLastCall().andAnswer(() -> {
-            cdl.countDown();
-            return null;
-        }).times(1);
+        expectLastCall().andStubThrow(new AssertionError("update() should not be called as process was not updated"));
         replay(processStoreMock);
 
         // prepare statuschecker registry

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplConsumerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplConsumerTest.java
@@ -498,7 +498,7 @@ class TransferProcessManagerImplConsumerTest {
     }
 
     @Test
-    void cancelTransferProcess() throws InterruptedException {
+    void cancelTransferProcess_changesStateToError() throws InterruptedException {
         //arrange
         TransferProcess process = createTransferProcess(TransferProcessStates.IN_PROGRESS);
         process.getProvisionedResourceSet().addResource(new TestResource());

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplConsumerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplConsumerTest.java
@@ -512,10 +512,9 @@ class TransferProcessManagerImplConsumerTest {
         expect(processStoreMock.nextForState(eq(TransferProcessStates.PROVISIONED.code()), anyInt())).andReturn(Collections.emptyList());
         expect(processStoreMock.nextForState(eq(TransferProcessStates.REQUESTED_ACK.code()), anyInt())).andReturn(Collections.emptyList());
         expect(processStoreMock.nextForState(eq(TransferProcessStates.IN_PROGRESS.code()), anyInt())).andReturn(Collections.singletonList(process));
-        processStoreMock.update(process);
         expect(processStoreMock.nextForState(anyInt(), anyInt())).andReturn(Collections.emptyList()).anyTimes();
 
-        // - Cancel processs
+        // - Cancel process
         expect(processStoreMock.find(process.getId())).andReturn(process);
         process.transitionError("Cancelled");
         processStoreMock.update(process);
@@ -535,6 +534,7 @@ class TransferProcessManagerImplConsumerTest {
         transferProcessManager.registerListener(listener);
 
         //act
+        // - start process and cancel it right away
         transferProcessManager.start(processStoreMock);
         transferProcessManager.cancelTransferProcess(process.getId());
 

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplConsumerTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplConsumerTest.java
@@ -16,6 +16,7 @@ package org.eclipse.dataspaceconnector.transfer.core.transfer;
 
 import org.eclipse.dataspaceconnector.spi.message.RemoteMessageDispatcherRegistry;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.transfer.TransferProcessListener;
 import org.eclipse.dataspaceconnector.spi.transfer.flow.DataFlowManager;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ProvisionManager;
 import org.eclipse.dataspaceconnector.spi.transfer.provision.ResourceManifestGenerator;
@@ -494,6 +495,54 @@ class TransferProcessManagerImplConsumerTest {
             assertThat(storedProcess).describedAs("Should exist in the TransferProcessStore").isNotNull();
             assertThat(storedProcess.getState()).isEqualTo(TransferProcessStates.PROVISIONING.code());
         });
+    }
+
+    @Test
+    void cancelTransferProcess() throws InterruptedException {
+        //arrange
+        TransferProcess process = createTransferProcess(TransferProcessStates.IN_PROGRESS);
+        process.getProvisionedResourceSet().addResource(new TestResource());
+
+        var cdl = new CountDownLatch(1);
+
+        // prepare process store
+        // - TransferProcessManager main loop
+        TransferProcessStore processStoreMock = mock(TransferProcessStore.class);
+        expect(processStoreMock.nextForState(eq(TransferProcessStates.INITIAL.code()), anyInt())).andReturn(Collections.emptyList());
+        expect(processStoreMock.nextForState(eq(TransferProcessStates.PROVISIONED.code()), anyInt())).andReturn(Collections.emptyList());
+        expect(processStoreMock.nextForState(eq(TransferProcessStates.REQUESTED_ACK.code()), anyInt())).andReturn(Collections.emptyList());
+        expect(processStoreMock.nextForState(eq(TransferProcessStates.IN_PROGRESS.code()), anyInt())).andReturn(Collections.singletonList(process));
+        processStoreMock.update(process);
+        expect(processStoreMock.nextForState(anyInt(), anyInt())).andReturn(Collections.emptyList()).anyTimes();
+
+        // - Cancel processs
+        expect(processStoreMock.find(process.getId())).andReturn(process);
+        process.transitionError("Cancelled");
+        processStoreMock.update(process);
+        replay(processStoreMock);
+
+        // prepare statuschecker registry
+        expect(statusCheckerRegistry.resolve(anyString())).andReturn((i, l) -> false).times(1);
+        replay(statusCheckerRegistry);
+
+        TransferProcessListener listener = mock(TransferProcessListener.class);
+        listener.error(anyObject(TransferProcess.class));
+        expectLastCall().andAnswer(() -> {
+            cdl.countDown();
+            return null;
+        });
+        replay(listener);
+        transferProcessManager.registerListener(listener);
+
+        //act
+        transferProcessManager.start(processStoreMock);
+        transferProcessManager.cancelTransferProcess(process.getId());
+
+        //assert
+        assertThat(cdl.await(TIMEOUT, TimeUnit.SECONDS)).isTrue();
+        verify(processStoreMock);
+        verify(statusCheckerRegistry);
+        assertThat(process.getState()).describedAs("State should be ERROR").isEqualTo(TransferProcessStates.ERROR.code());
     }
 
     private TransferProcess createTransferProcess(TransferProcessStates inState) {

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -31,7 +31,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.easymock.EasyMock.*;
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.niceMock;
 
 
 class TransferProcessManagerImplTest {
@@ -45,14 +46,14 @@ class TransferProcessManagerImplTest {
     void setup() {
         store = EasyMock.createMock(TransferProcessStore.class);
 
-        expect(store.processIdForTransferId("1")).andReturn(null);  // first invoke returns no as there is no store process
+        EasyMock.expect(store.processIdForTransferId("1")).andReturn(null);  // first invoke returns no as there is no store process
 
         store.create(EasyMock.isA(TransferProcess.class)); // store should only be called once
         EasyMock.expectLastCall();
 
-        expect(store.processIdForTransferId("1")).andReturn("2");
+        EasyMock.expect(store.processIdForTransferId("1")).andReturn("2");
 
-        expect(store.nextForState(EasyMock.anyInt(), EasyMock.anyInt())).andReturn(Collections.emptyList()).anyTimes();
+        EasyMock.expect(store.nextForState(EasyMock.anyInt(), EasyMock.anyInt())).andReturn(Collections.emptyList()).anyTimes();
 
         EasyMock.replay(store);
 

--- a/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
+++ b/core/transfer/src/test/java/org/eclipse/dataspaceconnector/transfer/core/transfer/TransferProcessManagerImplTest.java
@@ -31,8 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.easymock.EasyMock.createNiceMock;
-import static org.easymock.EasyMock.niceMock;
+import static org.easymock.EasyMock.*;
 
 
 class TransferProcessManagerImplTest {
@@ -46,14 +45,14 @@ class TransferProcessManagerImplTest {
     void setup() {
         store = EasyMock.createMock(TransferProcessStore.class);
 
-        EasyMock.expect(store.processIdForTransferId("1")).andReturn(null);  // first invoke returns no as there is no store process
+        expect(store.processIdForTransferId("1")).andReturn(null);  // first invoke returns no as there is no store process
 
         store.create(EasyMock.isA(TransferProcess.class)); // store should only be called once
         EasyMock.expectLastCall();
 
-        EasyMock.expect(store.processIdForTransferId("1")).andReturn("2");
+        expect(store.processIdForTransferId("1")).andReturn("2");
 
-        EasyMock.expect(store.nextForState(EasyMock.anyInt(), EasyMock.anyInt())).andReturn(Collections.emptyList()).anyTimes();
+        expect(store.nextForState(EasyMock.anyInt(), EasyMock.anyInt())).andReturn(Collections.emptyList()).anyTimes();
 
         EasyMock.replay(store);
 

--- a/extensions/in-memory/dataaddress-resolver-memory/build.gradle.kts
+++ b/extensions/in-memory/dataaddress-resolver-memory/build.gradle.kts
@@ -22,8 +22,8 @@ dependencies {
 }
 publishing {
     publications {
-        create<MavenPublication>("in-memory.assetindex") {
-            artifactId = "in-memory.assetindex"
+        create<MavenPublication>("in-memory.dataadressresolver") {
+            artifactId = "in-memory.dataadressresolver"
             from(components["java"])
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+projectVersion=0.0.1-SNAPSHOT.1
 javaVersion=11
 infoModelVersion=4.0.0
 jetBrainsAnnotationsVersion=15.0

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessManager.java
@@ -42,4 +42,8 @@ public interface TransferProcessManager {
      */
     TransferInitiateResponse initiateProviderRequest(DataRequest dataRequest);
 
+    /**
+     * Cancels a transfer process.
+     */
+    void cancelTransferProcess(String processId);
 }


### PR DESCRIPTION
Add method to TransferProcesManager to cancel processes given their id.

See https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/386