### PR TITLE
Feature/terraform gen cert

### DIFF
--- a/samples/05-file-transfer-cloud/README.md
+++ b/samples/05-file-transfer-cloud/README.md
@@ -45,14 +45,11 @@ It shouldn't take more than a couple of minutes, and when it's done it will log 
 , `vault-name`, `storage-container-name` and `storage-account-name`.
 > Take a note of these values!
 
-terraform output -raw certificate|base64 --decode>/tmp/cert.pfx
+Download the certificate used to authenticate the generated service principal against Azure Active Directory:
 
-client_id = "bd32d29e-35d0-47c4-93ca-23b076bfee74"
-storage-account-name = "algatikstorage"
-storage-container-name = "src-container"
-tenant-id = "836f6094-147a-44cc-8064-3dd900228759"
-vault-name = "algatik-vault"
-
+```bash
+terraform output -raw certificate | base64 --decode > cert.pfx
+```
 
 ## Update connector config
 

--- a/samples/05-file-transfer-cloud/README.md
+++ b/samples/05-file-transfer-cloud/README.md
@@ -28,24 +28,6 @@ The deployment scripts will provision all resources in Azure and AWS (that's why
 and store all access credentials in an Azure Vault (learn
 more [here](https://azure.microsoft.com/de-de/services/key-vault/#product-overview)).
 
-## Create a certificate for Azure
-
-The cloud resources hosted in Azure require a certificate for authentication, so you need to create one:
-
-```bash
-# create certificate:
-openssl req -newkey rsa:2048 -new -nodes -x509 -days 3650 -keyout key.pem -out cert.pem
-# create pfx file, we'll need this later (without password)
-openssl pkcs12 -export -in cert.pem -inkey key.pem -out cert.pfx    
-```
-
-Of course you can tune the parameters to your liking. Due to the way how Terraform interprets environment variables, we
-need to store the contents of the certificate in an environment variable named `TF_VAR_CERTIFICATE`:
-
-```bash
-TF_VAR_CERTIFICATE=$(<cert.pem)
-```
-
 ## Deploy cloud resources
 
 It's as simple as running the main terraform script:
@@ -62,6 +44,15 @@ enter "yes" and let terraform work its magic.
 It shouldn't take more than a couple of minutes, and when it's done it will log the `client_id`, `tenant_id`
 , `vault-name`, `storage-container-name` and `storage-account-name`.
 > Take a note of these values!
+
+terraform output -raw certificate|base64 --decode>/tmp/cert.pfx
+
+client_id = "bd32d29e-35d0-47c4-93ca-23b076bfee74"
+storage-account-name = "algatikstorage"
+storage-container-name = "src-container"
+tenant-id = "836f6094-147a-44cc-8064-3dd900228759"
+vault-name = "algatik-vault"
+
 
 ## Update connector config
 
@@ -128,7 +119,7 @@ curl -X POST -H "Content-Type: application/json" -d @samples/05-file-transfer-cl
 like before that'll return a UUID. Using that UUID we can then query the status of the transfer process by executing:
 
 ```bash
-curl -X GET "http://localhost:9191/api/datarequest/<UUID>/state
+curl -X GET "http://localhost:9191/api/datarequest/<UUID>/state"
 ```
 
 which will return one of

--- a/samples/05-file-transfer-cloud/terraform/main.tf
+++ b/samples/05-file-transfer-cloud/terraform/main.tf
@@ -153,7 +153,7 @@ resource "azurerm_key_vault_certificate" "demo-main-identity-cert" {
   ]
 }
 
-# Retrieve the Certificate for the PRS Connector Consumer from the central Key Vault.
+# Retrieve the Certificate from the Key Vault.
 # Note that the data source is actually a Certificate in Key Vault, and not a Secret.
 # However this actually works, and retrieves the Certificate base64 encoded.
 # An advantage of this method is that the "Key Vault Secrets User" (read-only)

--- a/samples/05-file-transfer-cloud/terraform/main.tf
+++ b/samples/05-file-transfer-cloud/terraform/main.tf
@@ -3,19 +3,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.72.0"
+      version = "2.88.1"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "1.6.0"
+      version = "2.12.0"
     }
     aws = {
       source  = "hashicorp/aws"
       version = "3.45.0"
-    }
-    http = {
-      source  = "hashicorp/http"
-      version = ">=2.1.0"
     }
   }
 }
@@ -46,25 +42,28 @@ resource "azurerm_resource_group" "core-resourcegroup" {
 
 # App registration for the primary identity
 resource "azuread_application" "demo-app-id" {
-  display_name               = "PrimaryIdentity-${var.environment}"
-  available_to_other_tenants = false
+  display_name = "PrimaryIdentity-${var.environment}"
 }
 
+# Allow the app to authenticate with the generated principal
 resource "azuread_application_certificate" "demo-main-identity-cert" {
   type                  = "AsymmetricX509Cert"
   application_object_id = azuread_application.demo-app-id.id
-  value                 = var.CERTIFICATE
-  end_date_relative     = "2400h"
+  value                 = azurerm_key_vault_certificate.demo-main-identity-cert.certificate_data_base64
+  end_date              = azurerm_key_vault_certificate.demo-main-identity-cert.certificate_attribute[0].expires
+  start_date            = azurerm_key_vault_certificate.demo-main-identity-cert.certificate_attribute[0].not_before
 }
 
+# Generate a service principal
 resource "azuread_service_principal" "main-app-sp" {
   application_id               = azuread_application.demo-app-id.application_id
   app_role_assignment_required = false
   tags = [
-  "terraform"]
+    "terraform"
+  ]
 }
 
-# Keyvault
+# Create central Key Vault for storing generated identity information and credentials
 resource "azurerm_key_vault" "main-vault" {
   name                        = "${var.environment}-vault"
   location                    = azurerm_resource_group.core-resourcegroup.location
@@ -86,18 +85,83 @@ resource "azurerm_role_assignment" "primary-id" {
   principal_id         = azuread_service_principal.main-app-sp.object_id
 }
 
-//# Role assignment that the primary identity may provision/deprovision azure resources
-//resource "azurerm_role_assignment" "primary-id-arm" {
-//  principal_id         = azuread_service_principal.main-app-sp.object_id
-//  scope                = data.azurerm_subscription.primary.id
-//  role_definition_name = "Contributor"
-//}
+#Role assignment so that the currently logged in user may access the vault, needed to add certificates
+resource "azurerm_role_assignment" "current-user-certificates" {
+  scope                = azurerm_key_vault.main-vault.id
+  role_definition_name = "Key Vault Certificates Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
 
 #Role assignment so that the currently logged in user may access the vault, needed to add secrets
-resource "azurerm_role_assignment" "current-user" {
+resource "azurerm_role_assignment" "current-user-secrets" {
   scope                = azurerm_key_vault.main-vault.id
   role_definition_name = "Key Vault Secrets Officer"
   principal_id         = data.azurerm_client_config.current.object_id
+}
+
+# Generate a certificate to be used by the generated principal
+resource "azurerm_key_vault_certificate" "demo-main-identity-cert" {
+  name         = "demo-app-id-certificate"
+  key_vault_id = azurerm_key_vault.main-vault.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      # Server Authentication = 1.3.6.1.5.5.7.3.1
+      # Client Authentication = 1.3.6.1.5.5.7.3.2
+      extended_key_usage = ["1.3.6.1.5.5.7.3.1"]
+
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=${azurerm_resource_group.core-resourcegroup.name}"
+      validity_in_months = 12
+    }
+  }
+  depends_on = [
+    azurerm_role_assignment.current-user-certificates
+  ]
+}
+
+# Retrieve the Certificate for the PRS Connector Consumer from the central Key Vault.
+# Note that the data source is actually a Certificate in Key Vault, and not a Secret.
+# However this actually works, and retrieves the Certificate base64 encoded.
+# An advantage of this method is that the "Key Vault Secrets User" (read-only)
+# role is then sufficient to export the certificate.
+# This is documented at https://docs.microsoft.com/azure/key-vault/certificates/how-to-export-certificate.
+data "azurerm_key_vault_secret" "certificate" {
+  name         = azurerm_key_vault_certificate.demo-main-identity-cert.name
+  key_vault_id = azurerm_key_vault.main-vault.id
 }
 
 #storage account
@@ -112,19 +176,19 @@ resource "azurerm_storage_account" "main-blobstore" {
 }
 
 # storage container
-resource "azurerm_storage_container" "main-blob-container"{
+resource "azurerm_storage_container" "main-blob-container" {
 
-  name = "src-container"
+  name                 = "src-container"
   storage_account_name = azurerm_storage_account.main-blobstore.name
 }
 
 # put a file as blob to the storage container
 resource "azurerm_storage_blob" "testfile" {
-  name = "test-document.txt"
-  storage_account_name = azurerm_storage_account.main-blobstore.name
+  name                   = "test-document.txt"
+  storage_account_name   = azurerm_storage_account.main-blobstore.name
   storage_container_name = azurerm_storage_container.main-blob-container.name
-  type = "Block"
-  source = "test-document.txt"
+  type                   = "Block"
+  source                 = "test-document.txt"
 }
 
 // primary key for the blob store
@@ -133,7 +197,7 @@ resource "azurerm_key_vault_secret" "blobstorekey" {
   value        = azurerm_storage_account.main-blobstore.primary_access_key
   key_vault_id = azurerm_key_vault.main-vault.id
   depends_on = [
-  azurerm_role_assignment.current-user]
+  azurerm_role_assignment.current-user-secrets]
 }
 
 // the AWS access credentials
@@ -142,7 +206,7 @@ resource "azurerm_key_vault_secret" "aws-keyid" {
   value        = aws_iam_access_key.access_key.id
   key_vault_id = azurerm_key_vault.main-vault.id
   depends_on = [
-  azurerm_role_assignment.current-user]
+  azurerm_role_assignment.current-user-secrets]
 }
 
 resource "azurerm_key_vault_secret" "aws-secret" {
@@ -150,7 +214,7 @@ resource "azurerm_key_vault_secret" "aws-secret" {
   value        = aws_iam_access_key.access_key.secret
   key_vault_id = azurerm_key_vault.main-vault.id
   depends_on = [
-  azurerm_role_assignment.current-user]
+  azurerm_role_assignment.current-user-secrets]
 }
 
 resource "azurerm_key_vault_secret" "aws-credentials" {
@@ -161,5 +225,5 @@ resource "azurerm_key_vault_secret" "aws-credentials" {
     "secretAccessKey" = aws_iam_access_key.access_key.secret
   })
   depends_on = [
-  azurerm_role_assignment.current-user]
+  azurerm_role_assignment.current-user-secrets]
 }

--- a/samples/05-file-transfer-cloud/terraform/output.tf
+++ b/samples/05-file-transfer-cloud/terraform/output.tf
@@ -6,11 +6,16 @@ output "tenant-id" {
   value = data.azurerm_client_config.current.tenant_id
 }
 
+output "certificate" {
+  value     = data.azurerm_key_vault_secret.certificate.value
+  sensitive = true
+}
+
 output "vault-name" {
   value = azurerm_key_vault.main-vault.name
 }
 
-output "storage-account-name"{
+output "storage-account-name" {
   value = azurerm_storage_account.main-blobstore.name
 }
 

--- a/samples/05-file-transfer-cloud/terraform/variables.tf
+++ b/samples/05-file-transfer-cloud/terraform/variables.tf
@@ -13,8 +13,3 @@ variable "aws_region" {
 variable "environment" {
   description = "identifying string that is used in all azure resources"
 }
-
-variable "CERTIFICATE" {
-  type        = string
-  description = "private key file for the primary azure app SP"
-}


### PR DESCRIPTION
sample 5: Generate X.509 certificate in Terraform, rather than on local machine.

Deployment fails against upstream main because of https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/381, but I tested it against Agera main with some minor adaptations.