### PR TITLE
Call TransferProcessListeners before persisting state change

### DIFF
--- a/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManager.java
+++ b/core/transfer/src/main/java/org/eclipse/dataspaceconnector/transfer/core/transfer/AsyncTransferProcessManager.java
@@ -183,7 +183,7 @@ public class AsyncTransferProcessManager extends TransferProcessObservable imple
         }
         var id = randomUUID().toString();
         var process = TransferProcess.Builder.newInstance().id(id).dataRequest(dataRequest).type(type).build();
-            updateState(process, p -> p.transitionInitial(), (p, l) -> l.created(p));
+        updateState(process, p -> p.transitionInitial(), (p, l) -> l.created(p));
         return TransferInitiateResult.success(process.getId());
     }
 

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessListener.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessListener.java
@@ -115,4 +115,22 @@ public interface TransferProcessListener {
      */
     default void requested(TransferProcess process) {
     }
+
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#REQUESTED_ACK REQUESTED_ACK}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
+    default void requestAck(TransferProcess process) {
+    }
+
+    /**
+     * Called after a {@link TransferProcess} has moved to state
+     * {@link TransferProcessStates#DEPROVISIONING_REQ DEPROVISIONING_REQ}.
+     *
+     * @param process the transfer process whose state has changed.
+     */
+    default void deprovisioningRequested(TransferProcess process) {
+    }
 }

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessListener.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/transfer/TransferProcessListener.java
@@ -21,9 +21,8 @@ import org.eclipse.dataspaceconnector.spi.types.domain.transfer.TransferProcessS
  * Interface implemented by listeners registered to observe transfer process
  * state changes via {@link TransferProcessObservable#registerListener(TransferProcessListener)}.
  * <p>
- * Note that the listener is not guaranteed to be called after a state change, in case
- * the application restarts. That is relevant when using a persistent transfer
- * store implementation.
+ * Note that the listener may be called more than once, in case the application
+ * restarts, and a persistent transfer store implementation is used.
  */
 public interface TransferProcessListener {
     /**

--- a/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
+++ b/spi/src/main/java/org/eclipse/dataspaceconnector/spi/types/domain/transfer/TransferProcess.java
@@ -160,7 +160,7 @@ public class TransferProcess {
 
     public void transitionRequestAck() {
         if (Type.PROVIDER == type) {
-            throw new IllegalStateException("Provider processes have no REQUESTED state");
+            throw new IllegalStateException("Provider processes have no REQUESTED_ACK state");
         }
         transition(TransferProcessStates.REQUESTED_ACK, TransferProcessStates.REQUESTED);
     }


### PR DESCRIPTION
Call TransferProcessListeners before persisting state change (rather than after) to ensure they are called at-least-once in case of crash.